### PR TITLE
Do not define [~ x] notation only to override it.

### DIFF
--- a/coq/theories/Init/Datatypes.v
+++ b/coq/theories/Init/Datatypes.v
@@ -91,7 +91,6 @@ Scheme nat_rec := Induction for nat Sort Set.
 Delimit Scope nat_scope with nat.
 Bind Scope nat_scope with nat.
 Arguments S _%nat.
-Arguments S _.
 
 Open Scope nat_scope. (* Originally in Peano.v *)
 
@@ -125,7 +124,7 @@ Delimit Scope identity_scope with identity.
 Notation "x = y :> A" := (@identity A x y)%identity : identity_scope.
 
 Notation "x = y" := (x = y :>_)%identity : identity_scope.
-Notation "x <> y  :> T" := (~ x = y :>T)%identity : identity_scope.
+Notation "x <> y  :> T" := (not (x = y :> T))%identity : identity_scope.
 Notation "x <> y" := (x <> y :>_)%identity : identity_scope.
 
 Local Open Scope identity_scope.

--- a/coq/theories/Init/Logic.v
+++ b/coq/theories/Init/Logic.v
@@ -31,7 +31,7 @@ Inductive False : Type :=.
 (** [not A], written [~A], is the negation of [A] *)
 Definition not (A:Type) : Type := A -> False.
 
-Notation "~ x" := (not x) : type_scope.
+(* Notation "~ x" := (not x) : type_scope. *)
 
 Hint Unfold not: core.
 

--- a/coq/theories/Init/Specif.v
+++ b/coq/theories/Init/Specif.v
@@ -169,7 +169,7 @@ Definition except := False_rec. (* for compatibility with previous versions *)
 
 Arguments except [P] _.
 
-Theorem absurd_set : forall (A:Prop) (C:Set), A -> ~ A -> C.
+Theorem absurd_set : forall (A:Prop) (C:Set), A -> not A -> C.
 Proof.
   intros A C h1 h2.
   apply False_rec.

--- a/coq/theories/Unicode/Utf8_core.v
+++ b/coq/theories/Unicode/Utf8_core.v
@@ -22,7 +22,7 @@ Notation "x → y" := (x -> y)
   (at level 99, y at level 200, right associativity): type_scope.
 
 Notation "x ↔ y" := (x <-> y) (at level 95, no associativity): type_scope.
-Notation "¬ x" := (~x) (at level 75, right associativity) : type_scope.
+Notation "¬ x" := (not x) (at level 75, right associativity) : type_scope.
 (*Notation "x ≠ y" := (x <> y) (at level 70) : type_scope.*)
 
 (* Abstraction *)


### PR DESCRIPTION
This lessens warning spam.