### PR TITLE
Fix with latest trunk

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # don't fall back on git if you interrupt or kill this script
 trap "exit 1" SIGINT SIGTERM

--- a/coq/theories/Init/Notations.v
+++ b/coq/theories/Init/Notations.v
@@ -1,6 +1,6 @@
 (************************************************************************)
 (*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
-(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2012     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2016     *)
 (*   \VV/  **************************************************************)
 (*    //   *      This file is distributed under the terms of the       *)
 (*         *       GNU Lesser General Public License Version 2.1        *)
@@ -59,7 +59,7 @@ Reserved Notation "( x , y , .. , z )" (at level 0).
 
 (** Notation "{ x }" is reserved and has a special status as component
     of other notations such as "{ A } + { B }" and "A + { B }" (which
-    are at the same level than "x + y");
+    are at the same level as "x + y");
     "{ x }" is at level 0 to factor with "{ x : A | P }" *)
 
 Reserved Notation "{ x }" (at level 0, x at level 99).
@@ -89,11 +89,5 @@ Open Scope type_scope.
 (** ML Tactic Notations *)
 
 Declare ML Module "ltac_plugin".
-Declare ML Module "coretactics".
-Declare ML Module "extratactics".
-Declare ML Module "g_auto".
-Declare ML Module "g_class".
-Declare ML Module "g_eqdecide".
-Declare ML Module "g_rewrite".
 
 Global Set Default Proof Mode "Classic".


### PR DESCRIPTION
The first commit allows me to test the `ci-hott` target on my machine.
The second commit fixes HoTT for Coq trunk.

I was worried it might break Travis tests in v8.6 branch but apparently this doesn't use the same branch so it shouldn't be a problem actually.